### PR TITLE
fix inconsistent license names

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cookiecutter https://github.com/MetaSUB-CAMP/CAMP_Module_Template
 3. Set up the module environment.
 
 ```Bash
-conda create -f configs/conda/module.yaml
+conda env create -f configs/conda/module.yaml
 conda activate module
 ```
 

--- a/camp_{{cookiecutter.module_slug}}/LICENSE
+++ b/camp_{{cookiecutter.module_slug}}/LICENSE
@@ -1,4 +1,4 @@
-{% if cookiecutter.open_source_license == 'MIT license' -%}
+{% if cookiecutter.open_source_license == 'MIT' -%}
 MIT License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -20,7 +20,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-{% elif cookiecutter.open_source_license == 'BSD license' %}
+{% elif cookiecutter.open_source_license == 'BSD' -%}
 
 BSD License
 
@@ -51,7 +51,7 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-{% elif cookiecutter.open_source_license == 'ISC license' -%}
+{% elif cookiecutter.open_source_license == 'ISCL' -%}
 ISC License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
@@ -79,7 +79,7 @@ limitations under the License.
 GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 
-    {{ cookiecutter.project_short_description }}
+    {{ cookiecutter.module_short_description }}
     Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.full_name }}
 
     This program is free software: you can redistribute it and/or modify

--- a/camp_{{cookiecutter.module_slug}}/README.md
+++ b/camp_{{cookiecutter.module_slug}}/README.md
@@ -19,7 +19,7 @@ Add longer description of your workflow's algorithmic contents
 
 ## Installation
 
-1. Clone repo from [Github](<https://github.com/MetaSUB-CAMP/camp_{{ cookiecutter.module_slug }}). 
+1. Clone repo from [Github](https://github.com/MetaSUB-CAMP/camp_{{ cookiecutter.module_slug }}).
 ```Bash
 git clone https://github.com/MetaSUB-CAMP/camp_{{ cookiecutter.module_slug }}
 ```
@@ -141,7 +141,7 @@ python3 /path/to/camp_{{ cookiecutter.module_slug }}/workflow/{{ cookiecutter.mo
 
 ## Credits
 
-- This package was created with [Cookiecutter](https://github.com/cookiecutter/cookiecutter>) as a simplified version of the [project template](https://github.com/audreyr/cookiecutter-pypackage>).
+- This package was created with [Cookiecutter](https://github.com/cookiecutter/cookiecutter) as a simplified version of the [project template](https://github.com/audreyr/cookiecutter-pypackage).
 {% if is_open_source %} 
 - Free software: {{ cookiecutter.open_source_license }} License
 - Documentation: https://camp-documentation.readthedocs.io/en/latest/{{ cookiecutter.module_slug }}.html

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,8 +4,8 @@
     "github_username": "lauren-mak",
     "module_name": "Binning",
     "module_slug": "{{ cookiecutter.module_name.lower().replace(' ', '_') }}",
-    "module_short_description": "The CAMP binning pipeline replicates the functionality of MetaWRAP (one of the original ensemble `binning methods <https://github.com/bxlab/metaWRAP>`_) with i) better dependency conflict management and ii) improved integration with new binning algorithms.",
+    "module_short_description": "The CAMP binning pipeline replicates the functionality of MetaWRAP (one of the original ensemble [binning methods](https://github.com/bxlab/metaWRAP)) with i) better dependency conflict management and ii) improved integration with new binning algorithms.",
     "version": "0.1.0",
     "create_author_file": "y",
-    "open_source_license": ["MIT", "BSD", "ISCL", "Apache Software License 2.0", "Not open source"]
+    "open_source_license": ["MIT", "BSD", "ISCL", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"]
 }


### PR DESCRIPTION
License names specified in `cookiecutter.json` don't match those in `camp_{{cookiecutter.module_slug}}/LICENSE`. This caused empty LICENSE files in numerous modules created using the template.

I also fixed some bad hyperlink formatting so that they are now displayed correctly in the README files. 

Finally, the conda env creation command from the template repo's README file on line 44 is incomplete. Fixed that as well.